### PR TITLE
[workaround] beforeGroup使う

### DIFF
--- a/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/domain/impl/work/WorkRepositoryImpl.kt
+++ b/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/domain/impl/work/WorkRepositoryImpl.kt
@@ -28,7 +28,7 @@ internal class WorkRepositoryImpl @Inject constructor(
         private val SYMBOL_POPULAR = "popular"
     }
 
-    override fun find(id: WorkId): Maybe<Work> =
+    override fun findById(id: WorkId): Maybe<Work> =
             if (idCache.get(id) != null) {
                 Maybe.just(idCache.get(id))
             } else {

--- a/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/domain/impl/work/episode/EpisodeRepositoryImpl.kt
+++ b/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/domain/impl/work/episode/EpisodeRepositoryImpl.kt
@@ -28,7 +28,7 @@ internal class EpisodeRepositoryImpl @Inject constructor(
             } else {
                 getAccessTokenService.execute().flatMap { accessToken ->
                     apiClient.getEpisodeList(
-                            fields = id.value,
+                            filterIds = id.value,
                             accessToken = accessToken
                     )
                 }.map {

--- a/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/domain/work/WorkRepository.kt
+++ b/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/domain/work/WorkRepository.kt
@@ -5,7 +5,7 @@ import io.reactivex.Single
 
 internal interface WorkRepository {
 
-    fun find(id: WorkId): Maybe<Work>
+    fun findById(id: WorkId): Maybe<Work>
 
     fun findAllByKeyword(keyword: String): Single<List<Work>>
 

--- a/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/usecase/impl/GetWorkUseCaseImpl.kt
+++ b/modules/work-dictionary/src/main/kotlin/com/kgmyshin/workDictionary/usecase/impl/GetWorkUseCaseImpl.kt
@@ -8,6 +8,6 @@ import io.reactivex.Maybe
 
 internal class GetWorkUseCaseImpl(private val repository: WorkRepository) : GetWorkUseCase {
 
-    override fun execute(id: WorkId): Maybe<Work> = repository.find(id)
+    override fun execute(id: WorkId): Maybe<Work> = repository.findById(id)
 
 }

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/domain/impl/WorkRepositoryImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/domain/impl/WorkRepositoryImplSpec.kt
@@ -33,17 +33,21 @@ internal class WorkRepositoryImplSpec : SubjectSpek<WorkRepositoryImpl>({
     }
 
     given("WorkDictionaryApiClient.getWorkList with fitlerId return GetWorkListResponseJson") {
+
         val id = WorkId(RandomHelper.randomString())
         val accessToken = RandomHelper.randomString()
         val responseJson = GetWorkListResponseJsonFactory.create()
-        Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
-        Mockito.`when`(apiClient.getWorkList(
-                filterIds = id.value,
-                accessToken = accessToken
-        )).thenReturn(Single.just(responseJson))
 
-        on("find") {
-            val maybe = subject.find(id)
+        beforeGroup {
+            Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
+            Mockito.`when`(apiClient.getWorkList(
+                    filterIds = id.value,
+                    accessToken = accessToken
+            )).thenReturn(Single.just(responseJson))
+        }
+
+        on("findById") {
+            val maybe = subject.findById(id)
 
             it("should return work") {
                 val expected = WorkConverter.convertToDomainModel(responseJson.workJsonList[0])
@@ -56,11 +60,15 @@ internal class WorkRepositoryImplSpec : SubjectSpek<WorkRepositoryImpl>({
         val keyword = RandomHelper.randomString()
         val accessToken = RandomHelper.randomString()
         val responseJson = GetWorkListResponseJsonFactory.create()
-        Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
-        Mockito.`when`(apiClient.getWorkList(
-                filterTitle = keyword,
-                accessToken = accessToken
-        )).thenReturn(Single.just(responseJson))
+
+        beforeGroup {
+            Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
+            Mockito.`when`(apiClient.getWorkList(
+                    filterTitle = keyword,
+                    accessToken = accessToken
+            )).thenReturn(Single.just(responseJson))
+        }
+
 
         on("findAllByKeyword") {
             val single = subject.findAllByKeyword(keyword)
@@ -76,11 +84,14 @@ internal class WorkRepositoryImplSpec : SubjectSpek<WorkRepositoryImpl>({
         val season = Season(RandomHelper.randomString())
         val accessToken = RandomHelper.randomString()
         val responseJson = GetWorkListResponseJsonFactory.create()
-        Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
-        Mockito.`when`(apiClient.getWorkList(
-                filterSeason = season.name,
-                accessToken = accessToken
-        )).thenReturn(Single.just(responseJson))
+
+        beforeGroup {
+            Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
+            Mockito.`when`(apiClient.getWorkList(
+                    filterSeason = season.name,
+                    accessToken = accessToken
+            )).thenReturn(Single.just(responseJson))
+        }
 
         on("findAllBySeason") {
             val single = subject.findAllBySeason(season)
@@ -95,12 +106,15 @@ internal class WorkRepositoryImplSpec : SubjectSpek<WorkRepositoryImpl>({
     given("WorkDictionaryApiClient.getWorkList with sortWatchersCount=asc return GetWorkListResponseJson") {
         val accessToken = RandomHelper.randomString()
         val responseJson = GetWorkListResponseJsonFactory.create()
-        Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
-        Mockito.`when`(apiClient.getWorkList(
-                sortWatchersCount = "asc",
-                accessToken = accessToken,
-                perPage = 50
-        )).thenReturn(Single.just(responseJson))
+
+        beforeGroup {
+            Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
+            Mockito.`when`(apiClient.getWorkList(
+                    sortWatchersCount = "asc",
+                    accessToken = accessToken,
+                    perPage = 50
+            )).thenReturn(Single.just(responseJson))
+        }
 
         on("findAllPopular") {
             val single = subject.findAllPopular()
@@ -109,6 +123,7 @@ internal class WorkRepositoryImplSpec : SubjectSpek<WorkRepositoryImpl>({
                 val expected = WorkConverter.convertToDomainModel(responseJson.workJsonList)
                 single.test().await().assertValue(expected).assertComplete()
             }
+
         }
     }
 

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/domain/impl/episode/EpisodeRepositoryImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/domain/impl/episode/EpisodeRepositoryImplSpec.kt
@@ -36,11 +36,14 @@ internal class EpisodeRepositoryImplSpec : SubjectSpek<EpisodeRepositoryImpl>({
         val id = EpisodeId(RandomHelper.randomString())
         val accessToken = RandomHelper.randomString()
         val responseJson = GetEpisodeListResponseJsonFactory.create()
-        Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
-        Mockito.`when`(apiClient.getEpisodeList(
-                filterIds = id.value,
-                accessToken = accessToken
-        )).thenReturn(Single.just(responseJson))
+
+        beforeGroup {
+            Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
+            Mockito.`when`(apiClient.getEpisodeList(
+                    filterIds = id.value,
+                    accessToken = accessToken
+            )).thenReturn(Single.just(responseJson))
+        }
 
         on("findById") {
             val maybe = subject.findById(id)
@@ -56,11 +59,14 @@ internal class EpisodeRepositoryImplSpec : SubjectSpek<EpisodeRepositoryImpl>({
         val workId = WorkId(RandomHelper.randomString())
         val accessToken = RandomHelper.randomString()
         val responseJson = GetEpisodeListResponseJsonFactory.create()
-        Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
-        Mockito.`when`(apiClient.getEpisodeList(
-                filterWorkId = workId.value,
-                accessToken = accessToken
-        )).thenReturn(Single.just(responseJson))
+
+        beforeGroup {
+            Mockito.`when`(getAccessTokenService.execute()).thenReturn(Single.just(accessToken))
+            Mockito.`when`(apiClient.getEpisodeList(
+                    filterWorkId = workId.value,
+                    accessToken = accessToken
+            )).thenReturn(Single.just(responseJson))
+        }
 
         on("findAllByWorkId") {
             val single = subject.findAllByWorkId(workId)

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/detail/WorkDetailPresenterSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/detail/WorkDetailPresenterSpec.kt
@@ -52,9 +52,11 @@ internal class WorkDetailPresenterSpec : SubjectSpek<WorkDetailPresenter>({
                 DomainHelper.episode(),
                 DomainHelper.episode()
         )
-        Mockito.`when`(getWorkUseCase.execute(workId)).thenReturn(Maybe.just(work))
-        Mockito.`when`(getEpisodeListUseCase.execute(workId)).thenReturn(Single.just(episodeList))
 
+        beforeGroup {
+            Mockito.`when`(getWorkUseCase.execute(workId)).thenReturn(Maybe.just(work))
+            Mockito.`when`(getEpisodeListUseCase.execute(workId)).thenReturn(Single.just(episodeList))
+        }
 
         on("onCreateView") {
             subject.onCreateView()

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/popular/PopularWorkListPresenterSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/popular/PopularWorkListPresenterSpec.kt
@@ -45,7 +45,10 @@ internal class PopularWorkListPresenterSpec : SubjectSpek<PopularWorkListPresent
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(getPopularWorkListUseCase.execute()).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(getPopularWorkListUseCase.execute()).thenReturn(Single.just(workList))
+        }
 
         on("onCreateView") {
             subject.onCreateView()

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/search/SearchWorkListPresenterSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/search/SearchWorkListPresenterSpec.kt
@@ -45,7 +45,10 @@ internal class SearchWorkListPresenterSpec : SubjectSpek<SearchWorkListPresenter
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(searchWorkListUseCase.execute(keyword)).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(searchWorkListUseCase.execute(keyword)).thenReturn(Single.just(workList))
+        }
 
         on("onUpdateKeyword") {
             subject.onUpdateKeyword(keyword)

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/season/BeforeSeasonWorkListPresenterSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/season/BeforeSeasonWorkListPresenterSpec.kt
@@ -45,7 +45,10 @@ internal class BeforeSeasonWorkListPresenterSpec : SubjectSpek<BeforeSeasonWorkL
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(getBeforeSeasonWorkListUseCase.execute()).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(getBeforeSeasonWorkListUseCase.execute()).thenReturn(Single.just(workList))
+        }
 
         on("onCreateView") {
 

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/season/NextSeasonWorkListPresenterSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/season/NextSeasonWorkListPresenterSpec.kt
@@ -45,7 +45,10 @@ internal class NextSeasonWorkListPresenterSpec : SubjectSpek<NextSeasonWorkListP
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(getNextSeasonWorkListUseCase.execute()).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(getNextSeasonWorkListUseCase.execute()).thenReturn(Single.just(workList))
+        }
 
         on("onCreateView") {
 

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/season/ThisSeasonWorkListPresenterSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/ui/work/season/ThisSeasonWorkListPresenterSpec.kt
@@ -45,7 +45,10 @@ internal class ThisSeasonWorkListPresenterSpec : SubjectSpek<ThisSeasonWorkListP
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(getThisSeasonWorkListUseCase.execute()).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(getThisSeasonWorkListUseCase.execute()).thenReturn(Single.just(workList))
+        }
 
         on("onCreateView") {
 

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetBeforeSeasonWorkListUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetBeforeSeasonWorkListUseCaseImplSpec.kt
@@ -27,7 +27,10 @@ internal class GetBeforeSeasonWorkListUseCaseImplSpec : SubjectSpek<GetBeforeSea
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(repository.findAllBySeason(Season.beforeSeason())).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(repository.findAllBySeason(Season.beforeSeason())).thenReturn(Single.just(workList))
+        }
 
         on("execute") {
             val single = subject.execute()

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetEpisodeListUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetEpisodeListUseCaseImplSpec.kt
@@ -29,7 +29,10 @@ internal class GetEpisodeListUseCaseImplSpec : SubjectSpek<GetEpisodeListUseCase
                 DomainHelper.episode(),
                 DomainHelper.episode()
         )
-        Mockito.`when`(repository.findAllByWorkId(workId)).thenReturn(Single.just(episodeList))
+
+        beforeGroup {
+            Mockito.`when`(repository.findAllByWorkId(workId)).thenReturn(Single.just(episodeList))
+        }
 
         on("execute") {
             val single = subject.execute(workId)

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetNextSeasonWorkListUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetNextSeasonWorkListUseCaseImplSpec.kt
@@ -27,7 +27,10 @@ internal class GetNextSeasonWorkListUseCaseImplSpec : SubjectSpek<GetNextSeasonW
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(repository.findAllBySeason(Season.nextSeason())).thenReturn(Single.just(workList))
+
+        beforeGroup {
+            Mockito.`when`(repository.findAllBySeason(Season.nextSeason())).thenReturn(Single.just(workList))
+        }
 
         on("execute") {
             val single = subject.execute()

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetPopularWorkListUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetPopularWorkListUseCaseImplSpec.kt
@@ -26,7 +26,9 @@ internal class GetPopularWorkListUseCaseImplSpec : SubjectSpek<GetPopularWorkLis
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(repository.findAllPopular()).thenReturn(Single.just(workList))
+        beforeGroup {
+            Mockito.`when`(repository.findAllPopular()).thenReturn(Single.just(workList))
+        }
 
         on("execute") {
             val single = subject.execute()

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetThisSeasonWorkListUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetThisSeasonWorkListUseCaseImplSpec.kt
@@ -27,7 +27,9 @@ internal class GetThisSeasonWorkListUseCaseImplSpec : SubjectSpek<GetThisSeasonW
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(repository.findAllBySeason(Season.thisSeason())).thenReturn(Single.just(workList))
+        beforeGroup {
+            Mockito.`when`(repository.findAllBySeason(Season.thisSeason())).thenReturn(Single.just(workList))
+        }
 
         on("execute") {
             val single = subject.execute()

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetWorkUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/GetWorkUseCaseImplSpec.kt
@@ -22,10 +22,13 @@ internal class GetWorkUseCaseImplSpec : SubjectSpek<GetWorkUseCaseImpl>({
         GetWorkUseCaseImpl(repository)
     }
 
-    given("WorkRepository.find return work") {
+    given("WorkRepository.findById return work") {
         val workId = WorkId(RandomHelper.randomString())
         val work = DomainHelper.work()
-        Mockito.`when`(repository.find(workId)).thenReturn(Maybe.just(work))
+
+        beforeGroup {
+            Mockito.`when`(repository.findById(workId)).thenReturn(Maybe.just(work))
+        }
 
         on("execute") {
             val maybe = subject.execute(workId)

--- a/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/SearchWorkListUseCaseImplSpec.kt
+++ b/modules/work-dictionary/src/test/java/com/kgmyshin/workDictionary/usecase/impl/SearchWorkListUseCaseImplSpec.kt
@@ -28,7 +28,9 @@ internal class SearchWorkListUseCaseImplSpec : SubjectSpek<SearchWorkListUseCase
                 DomainHelper.work(),
                 DomainHelper.work()
         )
-        Mockito.`when`(repository.findAllByKeyword(keyword)).thenReturn(Single.just(workList))
+        beforeGroup {
+            Mockito.`when`(repository.findAllByKeyword(keyword)).thenReturn(Single.just(workList))
+        }
 
         on("execute") {
             val single = subject.execute(keyword)


### PR DESCRIPTION
下記のテストは一つ目が失敗する。初めのテストも `Mockito.when(a.execute).thenReturn("b")` が適用されるため。

```
Spek {

  val a: A

  given() {
    Mockito.when(a.execute).thenReturn("a")

    on() {
      it() {
        assertEquals("a", a.execute)
      }
    }
  }

  given() {
    Mockito.when(a.execute).thenReturn("b")

    on() {
      it() {
        assertEquals("b", a.execute)
      }
    }
  }

}
```

下記のように 例えば `beforeGroup` を使うことで回避できる

```
Spek {

  val a: A

  given() {

    beforeGroup {
      Mockito.when(a.execute).thenReturn("a")
    }

    on() {
      it() {
        assertEquals("a", a.execute)
      }
    }
  }

  given() {

    beforeGroup {
      Mockito.when(a.execute).thenReturn("b")
    }

    on() {
      it() {
        assertEquals("b", a.execute)
      }
    }
  }

}
```